### PR TITLE
fix: memory persistence deadlock on DeleteByFilter

### DIFF
--- a/persistence/MemoryPersistence.go
+++ b/persistence/MemoryPersistence.go
@@ -408,6 +408,7 @@ func (c *MemoryPersistence) DeleteByFilter(correlationId string, filterFunc func
 		}
 	}
 	if deleted == 0 {
+		c.Lock.Unlock()
 		return nil
 	}
 


### PR DESCRIPTION
Quick fix for a deadlock issue in DeleteByFilter.